### PR TITLE
togglePicker, and some calendar changes

### DIFF
--- a/src/app/directives/calendar/calendar.directive.js
+++ b/src/app/directives/calendar/calendar.directive.js
@@ -247,11 +247,23 @@ class CalendarController {
   }
 
   showLeftArrow() {
-    return this.minMonth() ? !this.minMonth().isSame(this.getMonth().clone().subtract(1, 'M'), 'M') : true;
+    if (this.minMonth()) {
+      return !this.minMonth().isSame(this.getMonth().clone().subtract(1, 'M'), 'M');
+    } else if (this.minDay()) {
+      return !this.minDay().isSame(this.getMonth(), 'M');
+    } else {
+      return true;
+    }
   }
 
   showRightArrow() {
-    return this.maxMonth() ? !this.maxMonth().isSame(this.getMonth().clone().add(1, 'M'), 'M') : true;
+    if (this.maxMonth()) {
+      return !this.maxMonth().isSame(this.getMonth().clone().add(1, 'M'), 'M');
+    } else if (this.maxDay()) {
+      return !this.maxDay().isSame(this.getMonth(), 'M');
+    } else {
+      return true;
+    }
   }
 
   _showInput() {

--- a/src/app/directives/date-range-picker/date-range-picker.directive.js
+++ b/src/app/directives/date-range-picker/date-range-picker.directive.js
@@ -258,6 +258,10 @@ class DateRangePickerController {
       let oldStart = oldRange[0];
       let oldEnd = oldRange[1];
 
+      if (this.maxDay() && newStart.isSame(this.maxDay(), 'M')) {
+        newStart = newStart.clone().subtract(1, 'M');
+      }
+
       if (!this.startCalendar && !this.endCalendar) {
         this.startCalendar = newStart;
         this.endCalendar = newStart.clone().add(1, 'M');

--- a/src/app/directives/ob-date-range-picker/ob-date-range-picker.directive.js
+++ b/src/app/directives/ob-date-range-picker/ob-date-range-picker.directive.js
@@ -48,6 +48,7 @@ class ObDateRangePickerController {
 
     this.api && Object.assign(this.api, {
       setDateRange: this.setDateRange.bind(this),
+      togglePicker: this.togglePicker.bind(this),
       render: () => {
         this.render();
         this.pickerApi.render();

--- a/src/app/directives/ob-date-range-picker/ob-date-range-picker.directive.spec.js
+++ b/src/app/directives/ob-date-range-picker/ob-date-range-picker.directive.spec.js
@@ -29,7 +29,8 @@ describe('directive ob-date-range-picker', function () {
           start: moment().startOf('month'),
           end: moment()
         }
-      ]
+      ],
+      pickerApi: {}
     };
   }));
 
@@ -65,6 +66,32 @@ describe('directive ob-date-range-picker', function () {
     $rootScope.$digest();
 
     expect(picker.isPickerVisible).toEqual(true);
+  });
+
+  it('should hide picker after second toggle', () => {
+    prepare(defaultOptions);
+    picker.togglePicker();
+    picker.togglePicker();
+    $rootScope.$digest();
+
+    expect(picker.isPickerVisible).toEqual(false);
+  });
+
+  it('should show picker after first toggle using api', () => {
+    prepare(defaultOptions);
+    $scope.picker.pickerApi.togglePicker();
+    $rootScope.$digest();
+
+    expect(picker.isPickerVisible).toEqual(true);
+  });
+
+  it('should hide picker after second toggle using api', () => {
+    prepare(defaultOptions);
+    $scope.picker.pickerApi.togglePicker();
+    $scope.picker.pickerApi.togglePicker();
+    $rootScope.$digest();
+
+    expect(picker.isPickerVisible).toEqual(false);
   });
 
   it('should show 4 predefined, when the last is custom', () => {


### PR DESCRIPTION
Hi,
  First of all, I can definitely break this up into separate PRs if either change is not workable, but both seem relatively harmless, so I figured grouping them together may not be a big deal.

The first commit is the result of issue #10, adding `togglePicker` to the api option for ob-daterangepicker, with tests.

The second commit was to clean up some edge-casing for calendars. It's two separate changes, after which the calendars will never be able to show a month with no valid days to select. One change is to the `show(Left/Right)Arrow` functions, which now take `(min/max)Day` into account, so you can not move past the month which contains that day in the invalid direction. The other change never allows the left (start) calendar to contain the maxDay, as this forces the right calendar to appear in an invalid month.

I didn't add tests for the second commit, as there was no precedent to build off of, but here is a plunkr demo'ing the functionallity: http://plnkr.co/edit/8rMpP95hAS5LNVx3Ao2D?p=preview

Please let me know if there is anything else I can do.

Thanks,
James